### PR TITLE
Update CoC link to PSF policies site

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -22,4 +22,4 @@ For any report that involves the above admins/moderators, email
 conduct-wg@python.org instead.
 
 [Python Packaging Authority]: https://github.com/pypa/
-[PSF Code of Conduct]: https://www.python.org/psf/conduct/
+[PSF Code of Conduct]: https://policies.python.org/python.org/code-of-conduct/


### PR DESCRIPTION
The PSF Code of Conduct is now at https://policies.python.org/python.org/code-of-conduct/

There's a redirect from the old one to the new one (https://github.com/python/pythondotorg/pull/2399) but let's link directly to the new home.